### PR TITLE
Fix blank widgets by adding fallback entries and injecting missing Na…

### DIFF
--- a/Helldivers Companion Galaxy Map Widget/Helldivers_Companion_Galaxy_Map_Widget.swift
+++ b/Helldivers Companion Galaxy Map Widget/Helldivers_Companion_Galaxy_Map_Widget.swift
@@ -26,7 +26,8 @@ struct GalaxyMapProvider: TimelineProvider {
             var entries: [GalaxyMapEntry] = []
 
             guard let data = await dataProvider.fetchMapData() else {
-                completion(Timeline(entries: entries, policy: .atEnd))
+                let fallback = GalaxyMapEntry(date: Date(), campaigns: [], defenseCampaigns: [], planets: [])
+                completion(Timeline(entries: [fallback], policy: .after(Date().addingTimeInterval(300))))
                 return
             }
 

--- a/Helldivers Companion Major Order Widget/Helldivers_Companion_Major_Order_Widget.swift
+++ b/Helldivers Companion Major Order Widget/Helldivers_Companion_Major_Order_Widget.swift
@@ -50,7 +50,8 @@ struct MajorOrderProvider: TimelineProvider {
             var entries: [MajorOrderEntry] = []
 
             guard let data = await dataProvider.fetchOrderData() else {
-                completion(Timeline(entries: entries, policy: .atEnd))
+                let fallback = MajorOrderEntry(date: Date(), majorOrder: nil, taskPlanets: [], taskProgress: nil, factionColor: .yellow, progressString: nil, progress: nil, orderType: nil)
+                completion(Timeline(entries: [fallback], policy: .after(Date().addingTimeInterval(300))))
                 return
             }
 

--- a/Helldivers Companion Widgets/Helldivers_Companion_Planet_Widgets.swift
+++ b/Helldivers Companion Widgets/Helldivers_Companion_Planet_Widgets.swift
@@ -30,7 +30,15 @@ struct PlanetStatusProvider: TimelineProvider {
             var entries: [SimplePlanetStatus] = []
 
             guard let data = await dataProvider.fetchPlanetData() else {
-                completion(Timeline(entries: entries, policy: .atEnd))
+                let fallback = SimplePlanetStatus(
+                    date: Date(),
+                    planetName: "Data Unavailable",
+                    liberation: 0,
+                    playerCount: 0,
+                    liberationType: .liberation,
+                    campaignType: 0
+                )
+                completion(Timeline(entries: [fallback], policy: .after(Date().addingTimeInterval(300))))
                 return
             }
 
@@ -66,6 +74,18 @@ struct PlanetStatusProvider: TimelineProvider {
                 }
 
                 print("appending entry!")
+            }
+
+            if entries.isEmpty {
+                let fallback = SimplePlanetStatus(
+                    date: Date(),
+                    planetName: "No Active Campaigns",
+                    liberation: 0,
+                    playerCount: 0,
+                    liberationType: .liberation,
+                    campaignType: 0
+                )
+                entries.append(fallback)
             }
 
             completion(Timeline(entries: entries, policy: .atEnd))
@@ -146,6 +166,7 @@ struct Helldivers_Companion_WidgetsEntryView: View {
                 // PlanetsDataModel.shared is a structurally-required environment value for PlanetView;
                 // all actual widget data flows through entry fields — the viewModel is never consulted for fetching.
                 ).environment(PlanetsDataModel.shared)
+                    .environment(NavigationPather())
                     .padding(.horizontal)
                     .padding(.vertical, 5)
                 

--- a/Helldivers Companion Widgets/Helldivers_Companion_Planet_Widgets.swift
+++ b/Helldivers Companion Widgets/Helldivers_Companion_Planet_Widgets.swift
@@ -86,6 +86,8 @@ struct PlanetStatusProvider: TimelineProvider {
                     campaignType: 0
                 )
                 entries.append(fallback)
+                completion(Timeline(entries: entries, policy: .after(Date().addingTimeInterval(5 * 60))))
+                return
             }
 
             completion(Timeline(entries: entries, policy: .atEnd))

--- a/Helldivers Companion.xcodeproj/project.pbxproj
+++ b/Helldivers Companion.xcodeproj/project.pbxproj
@@ -2839,7 +2839,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.12;
+				MARKETING_VERSION = 3.8.13;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2878,7 +2878,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.12;
+				MARKETING_VERSION = 3.8.13;
 				OTHER_LDFLAGS = "-ObjC";
 				"OTHER_LDFLAGS[arch=*]" = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion";
@@ -2910,7 +2910,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Helldivers-Companion-News-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2938,7 +2938,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Helldivers-Companion-News-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2966,7 +2966,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp.Helldivers-Companion-Watch-Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -2996,7 +2996,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp.Helldivers-Companion-Watch-Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3026,7 +3026,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Helldivers-Companion-Galaxy-Map-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3054,7 +3054,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Helldivers-Companion-Galaxy-Map-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3082,7 +3082,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.War-Monitor-Total-Player-Count-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3110,7 +3110,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.War-Monitor-Total-Player-Count-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3138,7 +3138,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp.War-Monitor-Total-Player-Count-Watch-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3168,7 +3168,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp.War-Monitor-Total-Player-Count-Watch-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3202,7 +3202,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.12;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3237,7 +3237,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.8.12;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3267,7 +3267,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Helldivers-Companion-Major-Order-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3295,7 +3295,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Helldivers-Companion-Major-Order-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3323,7 +3323,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp.Helldivers-Companion-Major-Order-Watch-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3353,7 +3353,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp.Helldivers-Companion-Major-Order-Watch-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3384,7 +3384,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Stratagem-Hero-High-Score-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3413,7 +3413,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Stratagem-Hero-High-Score-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3442,7 +3442,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp.Stratagem-Hero-High-Score-Watch-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3473,7 +3473,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.watchkitapp.Stratagem-Hero-High-Score-Watch-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -3503,7 +3503,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Helldivers-Companion-Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -3531,7 +3531,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.8.11;
+				MARKETING_VERSION = 3.8.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.poole.james.Helldivers-Companion.Helldivers-Companion-Widgets";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
…vigationPather environment

- Add fallback timeline entries to planet, galaxy map, and major order widgets so WidgetKit always has something to render on network failure or when no campaigns are active, instead of completing with an empty entries array which causes a blank widget
- Use a 5-minute retry policy on the failure path instead of .atEnd
- Inject NavigationPather into the widget's PlanetView environment, fixing a fatal crash from the missing @Observable environment object that was the primary cause of the blank systemMedium/systemLarge widget
- Bump all target versions to 3.8.13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Widgets now show fallback content (e.g., "Data Unavailable" / "No Active Campaigns") when data can't be fetched and schedule automatic refreshes instead of stopping updates.
  * Ensured widgets always display at least one entry and continue refreshing (retry ~5 minutes) on failures.

* **Chores**
  * Updated app version to 3.8.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->